### PR TITLE
Yield tuple of window instead of actual deque

### DIFF
--- a/minibelt.py
+++ b/minibelt.py
@@ -340,10 +340,10 @@ def window(iterable, size=2):
     """
     iterable = iter(iterable)
     d = deque(islice(iterable, size), size)
-    yield d
+    yield tuple(d)
     for x in iterable:
         d.append(x)
-        yield d
+        yield tuple(d)
 
 
 def dmerge(d1, d2, merge_func=None):

--- a/minibelt.py
+++ b/minibelt.py
@@ -333,17 +333,21 @@ def chunks(seq, chunksize, process=tuple):
 
 
 
-def window(iterable, size=2):
+def window(iterable, size=2, cast=tuple):
     """
         Yields iterms by bunch of a given size, but rolling only one item
         in and out at a time when iterating.
+
+        By default, this will cast the window to a tuple before yielding it;
+        however, any function that will accept an iterable as its argument
+        is a valid target.
     """
     iterable = iter(iterable)
     d = deque(islice(iterable, size), size)
-    yield tuple(d)
+    yield cast(d)
     for x in iterable:
         d.append(x)
-        yield tuple(d)
+        yield cast(d)
 
 
 def dmerge(d1, d2, merge_func=None):


### PR DESCRIPTION
By yielding the actual deque instead of a tuple (for example), the calling code can mutate future results.

Example:

```python
w = window(range(10), size=4)
g = next(w)
g[3] = 1   # deque([0, 1, 2, 1], maxlen=4)
next(w)    # deque([1, 2, 1, 4], maxlen=4)
```

By yielding a tuple instead, future results are ensured to be "pure".

However, this may or may not be intended functionality. I ran into this issue with an implementation of window that does the exact same thing.