### PR TITLE
fix: install err for some py versions and locales

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     py_modules=['minibelt'],
     author_email="lesametlemax@gmail.com",
     description="One-file utility module filled with helper functions for day to day Python programming",
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', 'rb').read().decode('utf-8'),
     classifiers=[
         'Programming Language :: Python',
         "Intended Audience :: Information Technology",


### PR DESCRIPTION
if env var LANG=C
and with certain python3 versions install fails when trying to read
the contents of README.rst (which contains unicode characters)

This fix should work with any locale and should work with py2 and py3
