### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility.

### DIFF
--- a/minibelt.py
+++ b/minibelt.py
@@ -22,8 +22,14 @@ import unicodedata
 import codecs
 
 from itertools import islice, chain
-from collections import MutableSet, deque
+from collections import deque
 from datetime import datetime, timedelta, date, time
+
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
+
 
 __version__ = '0.2.1'
 


### PR DESCRIPTION
Fixes #7 